### PR TITLE
electron-prebuild has been deprecated/replaced by electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Likewise, it takes a bit of time to load a large organization - please be patien
 
 ## How to Run
 ```
-npm install electron-prebuilt -g
+npm install electron -g
 npm install shadow-cljs -g
 npm install
 


### PR DESCRIPTION
When I ran the electron-prebuilt version of this line I got the following warning:

npm WARN deprecated electron-prebuilt@1.4.13: electron-prebuilt has been renamed to electron. For more details, see http://electron.atom.io/blog/2016/08/16/npm-install-electron

Running the 'electron' version of the line instead does not cause the same warning